### PR TITLE
fix(text-layer): introduce layoutHeight, use it to fix vertical layout

### DIFF
--- a/modules/layers/src/text-layer/font-atlas-manager.ts
+++ b/modules/layers/src/text-layer/font-atlas-manager.ts
@@ -196,8 +196,9 @@ export default class FontAtlasManager {
     cache.set(this._key, fontAtlas);
   }
 
+  // eslint-disable-next-line max-statements
   private _generateFontAtlas(characterSet: Set<string>, cachedFontAtlas?: FontAtlas): FontAtlas {
-    const {fontFamily, fontWeight, fontSize, buffer, sdf, radius, cutoff} = this.props;
+    const {fontFamily, fontWeight, fontSize, buffer, sdf} = this.props;
     let canvas = cachedFontAtlas && cachedFontAtlas.data;
     if (!canvas) {
       canvas = document.createElement('canvas');

--- a/modules/layers/src/text-layer/utils.ts
+++ b/modules/layers/src/text-layer/utils.ts
@@ -12,6 +12,7 @@ export type Character = {
   width: number;
   height: number;
   layoutWidth: number;
+  layoutHeight: number;
   layoutOffsetY?: number;
 };
 
@@ -81,7 +82,8 @@ export function buildMapping({
         y: yOffset + row * rowHeight + buffer,
         width,
         height: rowHeight,
-        layoutWidth: width
+        layoutWidth: width,
+        layoutHeight: fontHeight,
       };
       x += width + buffer * 2;
     }
@@ -226,11 +228,16 @@ function transformRow(
   rowSize: [number, number]
 ) {
   let x = 0;
+  let rowHeight = 0;
 
   for (let i = startIndex; i < endIndex; i++) {
     const character = line[i];
     const frame = iconMapping[character];
     if (frame) {
+      if (!rowHeight) {
+        // frame.height should be a constant
+        rowHeight = frame.layoutHeight;
+      }
       leftOffsets[i] = x + frame.layoutWidth / 2;
       x += frame.layoutWidth;
     } else {
@@ -241,6 +248,7 @@ function transformRow(
   }
 
   rowSize[0] = x;
+  rowSize[1] = rowHeight;
 }
 
 /**


### PR DESCRIPTION
The proposed alignment changes seemed to break the vertical alignment of text when it wraps. I've partially reverted changes in my branch to `transformRow` but instead of incrementing the Y position by `frame.height` I increment by the new property `frame.layoutHeight`. The reason I introduced this new property was because otherwise the height of the row would be affected by the buffer.
